### PR TITLE
Change name to yaml-to-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# telco-ref-readme-builder
+# yaml-to-readme
 
 A CLI tool to recursively summarize YAML files in a directory using a local Ollama model, outputting results to a structured markdown file.
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sebrandon1/telco-ref-readme-builder
+module github.com/sebrandon1/yaml-to-readme
 
 go 1.24.4
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/sebrandon1/telco-ref-readme-builder/cmd"
+import "github.com/sebrandon1/yaml-to-readme/cmd"
 
 func main() {
 	_ = cmd.Execute()


### PR DESCRIPTION
Technically this has nothing to do with telco-reference, so I'm changing the name.